### PR TITLE
Fixed decode() for response of dmenu communicate()

### DIFF
--- a/examples/winmenu.py
+++ b/examples/winmenu.py
@@ -45,7 +45,7 @@ def win_menu(clients, l=10):
             stdout=subprocess.PIPE)
     menu_str = '\n'.join(sorted(clients.keys()))
     # Popen.communicate returns a tuple stdout, stderr
-    win_str = dmenu.communicate(menu_str.encode('utf-8'))[0].decode().rstrip()
+    win_str = dmenu.communicate(menu_str.encode('utf-8'))[0].decode('utf-8').rstrip()
     return clients.get(win_str, None)
 
 if __name__ == '__main__':


### PR DESCRIPTION
UnicodeDecodeError: 'ascii' codec can't decode byte 0xc2 in position 45: ordinal not in range(128)

Happens when there's a browser with github opened that has \xb7 in the title/caption that could not be decoded from utf-8 using 'ascii' codec.
