### PR TITLE
examples/winmenu.py to show unnumbered workspaces

### DIFF
--- a/examples/winmenu.py
+++ b/examples/winmenu.py
@@ -17,13 +17,12 @@ def i3clients():
     Each window text is of format "[workspace] window title (instance number)"
     """
     clients = {}
-    for ws_num in range(1,11):
-        workspace = i3.filter(num=ws_num)
-        if not workspace:
-            continue
-        workspace = workspace[0]
+    is_ws = lambda x: x['type'] == 4 and len(x['nodes'])
+    for workspace in i3.filter(function=is_ws):
+
         windows = i3.filter(workspace, nodes=[])
         instances = {}
+        
         # Adds windows and their ids to the clients dictionary
         for window in windows:
             win_str = '[%s] %s' % (workspace['name'], window['name'])


### PR DESCRIPTION
So far, the winmenu.py script showed only numbered workspaces in the number range 1,10. Now, it should show all workspaces, regardless of whether they are numbered or not. Only those are taken into account, that have windows in them. 
