### PR TITLE
Fix SyntaxError on fibonacci example

### DIFF
--- a/examples/fibonacci.py
+++ b/examples/fibonacci.py
@@ -3,11 +3,11 @@ import os
 import time
 
 term = os.environ.get('TERM', 'xterm')
-if 'rxvt-unicode' in term: 
+if 'rxvt-unicode' in term:
     term = 'urxvt'
 
 def fibonacci(num):
-    i3.exec(term)
+    i3.command('exec {}'.format(term))
     time.sleep(0.5)
     if num % 2 == 0:
         if num % 4 == 0:


### PR DESCRIPTION
`examples/fibonacci.py` was using `i3.exec`, which does not exist (actually, a `SyntaxError` is generated because `exec` is a Python keyword) -- it needs to call `i3.command` instead.
