### PR TITLE
Fixed winmenu example to support workspaces named with string

### DIFF
--- a/examples/winmenu.py
+++ b/examples/winmenu.py
@@ -25,7 +25,6 @@ def i3clients():
         windows = i3.filter(workspace, nodes=[])
         instances = {}
         # Adds windows and their ids to the clients dictionary
-        print(windows)
         for window in windows:
             win_str = '[%s] %s' % (workspace['name'], window['name'])
             # Appends an instance number if other instances are present
@@ -51,7 +50,6 @@ def win_menu(clients, l=10):
 
 if __name__ == '__main__':
     clients = i3clients()
-    print(clients)
     win_id = win_menu(clients)
     if win_id:
         i3.focus(con_id=win_id)

--- a/examples/winmenu.py
+++ b/examples/winmenu.py
@@ -17,14 +17,15 @@ def i3clients():
     Each window text is of format "[workspace] window title (instance number)"
     """
     clients = {}
-    for ws_num in range(1,11):
-        workspace = i3.filter(num=ws_num)
+    for ws_name in [w['name'] for w in i3.get_workspaces()]:
+        workspace = i3.filter(name = ws_name)
         if not workspace:
             continue
         workspace = workspace[0]
         windows = i3.filter(workspace, nodes=[])
         instances = {}
         # Adds windows and their ids to the clients dictionary
+        print(windows)
         for window in windows:
             win_str = '[%s] %s' % (workspace['name'], window['name'])
             # Appends an instance number if other instances are present
@@ -50,6 +51,7 @@ def win_menu(clients, l=10):
 
 if __name__ == '__main__':
     clients = i3clients()
+    print(clients)
     win_id = win_menu(clients)
     if win_id:
         i3.focus(con_id=win_id)


### PR DESCRIPTION
It was working only for number-named windows from 1 to 10, now it supports all existing workspaces using i3.get_workspaces()
