### PR TITLE
Remove white spaces from the key used to index into the window id's dict

### DIFF
--- a/examples/winmenu.py
+++ b/examples/winmenu.py
@@ -33,7 +33,7 @@ def i3clients():
                 win_str = '%s (%d)' % (win_str, instances[win_str])
             else:
                 instances[win_str] = 1
-            clients[win_str] = window['id']
+            clients[win_str.rstrip()] = window['id']
     return clients
 
 def win_menu(clients, l=10):


### PR DESCRIPTION
In function 'win_menu()' , where we access our key , we 'rsrtip' the 'win_str' variable, we also need to do the same in 'i3clients()' for 'win_str' when we save our key.

Else it does not allow us to choose window, who name end with white spaces. 

I faced this problem with  "Synaptic Package Manager"  on Ubuntu 12.04 whose Window name ends with a 
white space.
