### PR TITLE
If payload contains wrong utf-8, fallback to latin-1 encoding

### DIFF
--- a/i3.py
+++ b/i3.py
@@ -245,7 +245,11 @@ class Socket(object):
         msg_size = self.struct_header_size + msg_length
         # Message shouldn't be any longer than the data
         if data_size >= msg_size:
-            payload = data[self.struct_header_size:msg_size].decode('utf-8')
+            try:
+                payload = data[self.struct_header_size:msg_size].decode('utf-8')
+            except UnicodeDecodeError:
+                payload = data[self.struct_header_size:msg_size].decode('latin-1')
+
             payload = json.loads(payload)
             self.buffer = data[msg_size:]
             return payload


### PR DESCRIPTION
If there is wrong utf-8 in payload (for example - I have it sometimes in window titles) library raises exception UnicodeDecodeError. Commit handles the exception and decode string in old latin-1 way, so even wrong utf shows in a wierd way, but, at least, programs based on library works.
