### PR TITLE
docs: Fix a few typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Well, from [i3's website](http://i3wm.org/) itself:
 > advanced users and developers.
 
 i3-py contains tools for i3 users and Python developers. To avoid the confusion,
-I'll be refering to i3 as _i3-wm_ from here on.
+I'll be referring to i3 as _i3-wm_ from here on.
 
 
 Install
@@ -253,7 +253,7 @@ Exceptions
 There are three exceptions:
 
  - `i3.MessageTypeError`, raised when you use unavailable message type
- - `i3.EventTypeError`, raised when you use unavaible event type
+ - `i3.EventTypeError`, raised when you use unavailable event type
  - `i3.MessageError`, raised when i3 sends back an error (the exception contains
    that error string)
 

--- a/i3.py
+++ b/i3.py
@@ -372,7 +372,7 @@ def __call_cmd__(cmd):
 __socket__ = None
 def default_socket(socket=None):
     """
-    Returns i3.Socket object, which was initiliazed once with default values
+    Returns i3.Socket object, which was initialized once with default values
     if no argument is given.
     Otherwise sets the default socket to the given socket.
     """


### PR DESCRIPTION
There are small typos in:
- README.md
- i3.py

Fixes:
- Should read `unavailable` rather than `unavaible`.
- Should read `referring` rather than `refering`.
- Should read `initialized` rather than `initiliazed`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md